### PR TITLE
Update to MC 1.20.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.2
-loader_version=0.14.11
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.9
+loader_version=0.14.21
+#Fabric api
+fabric_version=0.86.0+1.20.1
+
 # Mod Properties
 mod_version=0.1
 maven_group=io.wispforest
 archives_base_name=owo-ui-academy
-# Dependencies
-# check this on https://fabricmc.net/develop
-fabric_version=0.68.1+1.19.3
 
 # https://maven.wispforest.io/io/wispforest/owo-lib/
-owo_version=0.9.3+1.19.3
+owo_version=0.11.1+1.20


### PR DESCRIPTION
Updates the project to Minecraft version 1.20.1. This will also let the pipeline re-run, letting the artifact get regenerated since currently there is no artifact to download. 